### PR TITLE
fix: add concurrency control to prevent duplicate agent assignments

### DIFF
--- a/.github/workflows/assign-adf-generate-agent.yml
+++ b/.github/workflows/assign-adf-generate-agent.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled, opened]
 
+concurrency:
+  group: adf-generate-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
   contents: write

--- a/.github/workflows/assign-adf-review-agent.yml
+++ b/.github/workflows/assign-adf-review-agent.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, labeled, synchronize]
 
+concurrency:
+  group: adf-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   issues: write

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ The repository includes four GitHub Actions workflows that orchestrate this flow
 | **Review Handoff** | `.github/workflows/handle-adf-review-results.yml` | Parses review comment → Routes back to generation agent (if errors) or approves |
 | **Escalation** | `.github/workflows/escalate-to-human-review.yml` | After 3 cycles → Adds `needs-human-review` label and alerts maintainers |
 
+> **Note:** Assignment workflows use `concurrency` groups to prevent duplicate agent sessions when multiple events fire simultaneously (e.g., issue created with label already applied).
+
 ### How Automatic Assignment Works
 
 The workflows use the GitHub GraphQL API with the `agentAssignment` input to assign Copilot with a specific custom agent:


### PR DESCRIPTION
When an issue is created with a label already applied, both 'opened' and 'labeled' events fire simultaneously, causing two parallel agent sessions.

Added concurrency groups to assignment workflows:
- assign-adf-generate-agent.yml: group by issue number
- assign-adf-review-agent.yml: group by PR number

With cancel-in-progress: true, duplicate runs are automatically cancelled.