### PR TITLE
fix: prevent duplicate agent assignments on issue creation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,16 @@ Issue + "adf-generate" label
 | `templates/*.json` | ADF pipeline JSON templates (Copy, Data Flow) |
 | `rules/best_practices.json` | Review rules (retry policies, naming, security, parameterization) |
 
+## Branch and PR Policy
+
+**Never commit directly to `main`.** All changes must be made on a feature branch and submitted via pull request.
+
+When making changes:
+1. Create a new branch with a descriptive name (e.g., `fix/issue-description`, `feature/new-capability`)
+2. Commit changes to the feature branch
+3. Push the branch and create a pull request
+4. Wait for review/approval before merging
+
 ## Conventions
 
 ### Agent Definition Structure


### PR DESCRIPTION
## Problem
When an issue is created with the adf-generate label already applied, both opened and labeled events fire simultaneously, causing two parallel agent sessions.

## Solution
Added concurrency control to assignment workflows with cancel-in-progress: true.

## Changes
- .github/workflows/assign-adf-generate-agent.yml - concurrency group by issue number
- .github/workflows/assign-adf-review-agent.yml - concurrency group by PR number
- README.md - note about concurrency behavior
- .github/copilot-instructions.md - added branch/PR policy