### PR TITLE
feat: add auto-approve workflow for Copilot-triggered runs

### DIFF
--- a/.github/workflows/auto-approve-copilot-runs.yml
+++ b/.github/workflows/auto-approve-copilot-runs.yml
@@ -1,0 +1,50 @@
+name: Auto-Approve Copilot Workflow Runs
+
+# This workflow automatically approves workflow runs triggered by the Copilot coding agent.
+# 
+# GitHub requires manual approval for workflows triggered by bot accounts (including Copilot).
+# This is a known platform limitation with no official workaround. This workflow uses the
+# GitHub API to programmatically approve these runs, enabling automatic agent-to-agent handoffs.
+#
+# Security: Only approves runs from copilot-swe-agent[bot] for specific workflows.
+
+on:
+  workflow_run:
+    workflows:
+      - "Assign ADF Review Agent to PR"
+      - "Handle ADF Review Results & Agent Handoff"
+    types: [requested]
+
+jobs:
+  approve-copilot-run:
+    runs-on: ubuntu-latest
+    # Only run if the workflow is waiting for approval
+    if: github.event.workflow_run.conclusion == 'action_required'
+    
+    steps:
+      - name: Check actor and approve if Copilot
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_PAT }}
+        run: |
+          ACTOR="${{ github.event.workflow_run.actor.login }}"
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+          
+          echo "Workflow run details:"
+          echo "  Actor: $ACTOR"
+          echo "  Run ID: $RUN_ID"
+          echo "  Workflow: $WORKFLOW_NAME"
+          
+          # Only approve runs from the Copilot coding agent
+          if [[ "$ACTOR" == "copilot-swe-agent[bot]" ]]; then
+            echo "✅ Actor is Copilot coding agent. Approving workflow run..."
+            
+            gh api \
+              --method POST \
+              "repos/${{ github.repository }}/actions/runs/${RUN_ID}/approve" \
+              && echo "✅ Workflow run approved successfully!" \
+              || echo "⚠️ Failed to approve workflow run (may already be approved or running)"
+          else
+            echo "❌ Actor is not Copilot coding agent. Skipping approval."
+            echo "   Manual approval required for runs from: $ACTOR"
+          fi


### PR DESCRIPTION
GitHub requires manual approval for workflows triggered by bot accounts, including the Copilot coding agent. This is a known platform limitation.

This workflow automatically approves runs from copilot-swe-agent[bot]:
- Triggers on workflow_run with action_required status
- Verifies actor is Copilot before approving
- Enables fully automatic agent-to-agent handoffs

Also updated:
- README: Document the limitation and solution
- README: Add Actions:write to PAT requirements
- README: Add troubleshooting entry for approval issues