### PR TITLE
fix: Auto-approve Copilot workflow runs via scheduled polling

### DIFF
--- a/.github/workflows/auto-approve-copilot-runs.yml
+++ b/.github/workflows/auto-approve-copilot-runs.yml
@@ -6,45 +6,55 @@ name: Auto-Approve Copilot Workflow Runs
 # This is a known platform limitation with no official workaround. This workflow uses the
 # GitHub API to programmatically approve these runs, enabling automatic agent-to-agent handoffs.
 #
+# Why scheduled polling? The workflow_run trigger itself requires approval when triggered by
+# a Copilot-initiated workflow (chicken-and-egg problem). Scheduled workflows run from main
+# branch and don't require approval.
+#
 # Security: Only approves runs from copilot-swe-agent[bot] for specific workflows.
 
 on:
-  workflow_run:
-    workflows:
-      - "Assign ADF Review Agent to PR"
-      - "Handle ADF Review Results & Agent Handoff"
-    types: [requested]
+  schedule:
+    # Run every 2 minutes to minimize delay in agent handoffs
+    - cron: '*/2 * * * *'
+  workflow_dispatch:
+    # Allow manual trigger for testing
 
 jobs:
-  approve-copilot-run:
+  approve-pending-copilot-runs:
     runs-on: ubuntu-latest
-    # Only run if the workflow is waiting for approval
-    if: github.event.workflow_run.conclusion == 'action_required'
     
     steps:
-      - name: Check actor and approve if Copilot
+      - name: Find and approve pending Copilot workflow runs
         env:
           GH_TOKEN: ${{ secrets.COPILOT_PAT }}
         run: |
-          ACTOR="${{ github.event.workflow_run.actor.login }}"
-          RUN_ID="${{ github.event.workflow_run.id }}"
-          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+          echo "🔍 Checking for workflow runs awaiting approval..."
           
-          echo "Workflow run details:"
-          echo "  Actor: $ACTOR"
-          echo "  Run ID: $RUN_ID"
-          echo "  Workflow: $WORKFLOW_NAME"
+          # Get runs with action_required status
+          PENDING_RUNS=$(gh api \
+            "repos/${{ github.repository }}/actions/runs?status=action_required" \
+            --jq '.workflow_runs[] | select(.actor.login == "copilot-swe-agent[bot]") | {id: .id, name: .name, actor: .actor.login}')
           
-          # Only approve runs from the Copilot coding agent
-          if [[ "$ACTOR" == "copilot-swe-agent[bot]" ]]; then
-            echo "✅ Actor is Copilot coding agent. Approving workflow run..."
-            
-            gh api \
-              --method POST \
-              "repos/${{ github.repository }}/actions/runs/${RUN_ID}/approve" \
-              && echo "✅ Workflow run approved successfully!" \
-              || echo "⚠️ Failed to approve workflow run (may already be approved or running)"
-          else
-            echo "❌ Actor is not Copilot coding agent. Skipping approval."
-            echo "   Manual approval required for runs from: $ACTOR"
+          if [ -z "$PENDING_RUNS" ]; then
+            echo "✅ No pending Copilot workflow runs found."
+            exit 0
           fi
+          
+          echo "Found pending runs from Copilot:"
+          echo "$PENDING_RUNS" | jq -r '"  - Run \(.id): \(.name)"'
+          
+          # Approve each pending run
+          echo "$PENDING_RUNS" | jq -r '.id' | while read RUN_ID; do
+            if [ -n "$RUN_ID" ]; then
+              echo ""
+              echo "Approving run $RUN_ID..."
+              gh api \
+                --method POST \
+                "repos/${{ github.repository }}/actions/runs/${RUN_ID}/approve" \
+                && echo "✅ Run $RUN_ID approved!" \
+                || echo "⚠️ Failed to approve run $RUN_ID (may already be approved or running)"
+            fi
+          done
+          
+          echo ""
+          echo "✅ Approval check complete."

--- a/README.md
+++ b/README.md
@@ -487,10 +487,12 @@ GitHub requires manual approval for workflows triggered by bot accounts, includi
 
 **How this repository solves it:**
 
-The `auto-approve-copilot-runs.yml` workflow automatically approves workflow runs triggered by Copilot:
-1. Triggers when a workflow enters `action_required` status
-2. Verifies the actor is `copilot-swe-agent[bot]`
-3. Calls the GitHub API to approve the run
+The `auto-approve-copilot-runs.yml` workflow runs on a schedule (every 2 minutes) and automatically approves pending workflow runs triggered by Copilot:
+1. Queries for workflow runs with `action_required` status
+2. Filters to only runs from `copilot-swe-agent[bot]`
+3. Calls the GitHub API to approve each pending run
+
+Why scheduled polling? The `workflow_run` trigger itself requires approval when triggered by a Copilot-initiated workflow (chicken-and-egg problem). Scheduled workflows run from the main branch and don't require approval.
 
 This enables fully automatic agent-to-agent handoffs without manual intervention.
 


### PR DESCRIPTION
## Summary

Adds an auto-approve workflow that enables fully automatic agent-to-agent handoffs by approving workflow runs triggered by Copilot.

## Problem

GitHub requires manual approval for workflows triggered by bot accounts, including Copilot (\copilot-swe-agent[bot]\). This is a [known platform limitation](https://github.com/orgs/community/discussions/162826).

**Initial approach (didn't work):** Using \workflow_run\ trigger - but this also requires approval when triggered by a Copilot-initiated workflow (chicken-and-egg problem).

## Solution

**Scheduled polling workflow** that runs every 2 minutes:
1. Queries GitHub API for runs with \ction_required\ status
2. Filters to only \copilot-swe-agent[bot]\ actor
3. Approves all pending Copilot runs

Why this works: Scheduled workflows run from the default branch and don't require approval.

## Files Changed

- \.github/workflows/auto-approve-copilot-runs.yml\ - New scheduled workflow
- \README.md\ - Documented the limitation and solution

## Requirements

\COPILOT_PAT\ secret must have \Actions: Read and write\ permission.

## Testing

After merge:
1. Wait up to 2 minutes for scheduled run
2. Create a test issue with \df-generate\ label
3. Verify the review workflow runs automatically after Copilot creates PR