### PR TITLE
fix: remove tools restriction from agent definitions

### DIFF
--- a/.github/agents/adf-generate.agent.md
+++ b/.github/agents/adf-generate.agent.md
@@ -1,7 +1,6 @@
 ---
 name: ADF Pipeline Generator
 description: Generates Azure Data Factory pipeline JSON definitions from issue requirements
-tools: ["read", "edit", "search"]
 ---
 
 # ADF Pipeline Generation Agent
@@ -94,15 +93,18 @@ Check against `rules/best_practices.json`:
 
 **Fix any issues before proceeding.**
 
-### 5. Create Pull Request
+### 5. Create Pull Request (using Safe Outputs)
 
-- Commit pipeline to `pipelines/<pipeline-name>.json`
-- Update PR description with:
-  - `Resolves #<issue-number>`
-  - Pipeline summary
-  - Self-review checklist
-  - Full pipeline JSON in code block
-- Add label `adf-pipeline`
+**CRITICAL**: You are running in a sandboxed workflow. To create PRs and comments, you MUST use the safe-output tools. Simply writing files won't create a PR.
+
+1. **Write the pipeline file** using the `edit` tool to create `pipelines/<pipeline-name>.json`
+
+2. **Call `create_pull_request`** safe-output tool with:
+   - `title`: Descriptive title for the pipeline
+   - `body`: PR description including `Resolves #<issue-number>`, pipeline summary, and self-review checklist
+
+3. **Call `add_comment`** safe-output tool to notify the issue:
+   - `body`: Message confirming pipeline generation with a note about the PR
 
 ### 6. Request Review
 

--- a/.github/agents/adf-review.agent.md
+++ b/.github/agents/adf-review.agent.md
@@ -1,7 +1,6 @@
 ---
 name: ADF Pipeline Review Agent
 description: Reviews Azure Data Factory pipeline JSON files for functional correctness, best practices, and common issues
-tools: ["read", "search"]
 ---
 
 # ADF Pipeline Review Agent
@@ -91,9 +90,11 @@ Query `rules/common_issues.json` for known issues:
 
 For each match, include the KB reference and resolution in your review.
 
-### 4. Post Review Results
+### 4. Post Review Results (using Safe Outputs)
 
-Post a structured comment on the PR:
+**CRITICAL**: You are running in a sandboxed workflow. To post comments and add labels, you MUST use the safe-output tools.
+
+**Call `add_comment`** safe-output tool to post a structured comment on the PR:
 
 ```markdown
 ## 🔍 ADF Pipeline Review Results
@@ -131,25 +132,27 @@ Post a structured comment on the PR:
 </details>
 ```
 
-### 5. Determine Outcome
+### 5. Determine Outcome (using Safe Outputs)
+
+Use the **`add_labels`** safe-output tool to set the appropriate label:
 
 **If ERRORS found:**
-- Add label: `changes-requested`
-- Comment:
+- Call `add_labels` with: `changes-requested`
+- Call `add_comment` with:
   ```
   @adf-generate — Please fix the errors listed above.
   ```
 
 **If only WARNINGS:**
-- Add label: `approved-with-warnings`
-- Comment:
+- Call `add_labels` with: `approved-with-warnings`
+- Call `add_comment` with:
   ```
   ✅ Pipeline approved with minor suggestions.
   ```
 
 **If CLEAN:**
-- Add label: `approved`
-- Comment:
+- Call `add_labels` with: `approved`
+- Call `add_comment` with:
   ```
   ✅ Pipeline passed all checks! Ready for merge.
   ```


### PR DESCRIPTION
The agent .md files had a tools: [] property in frontmatter that was restricting which tools the agent could see. This prevented the agent from accessing the safe-output MCP tools (create_pull_request, add_comment, etc).

Also updated agent instructions to explicitly mention using safe-output tools for creating PRs and adding comments/labels.