### PR TITLE
fix: escalate review severities — promote warnings to errors for secu…

### DIFF
--- a/.github/agents/adf-review.agent.md
+++ b/.github/agents/adf-review.agent.md
@@ -41,10 +41,10 @@ For each pipeline, check these categories. Classify findings as:
 | Check | Severity |
 |-------|----------|
 | Has `name` | ERROR |
-| Has `description` | WARNING |
+| Has `description` | ERROR |
 | Has activities | ERROR |
-| Has `annotations` | INFO |
-| Has `folder` | INFO |
+| Has `annotations` | WARNING |
+| Has `folder` | WARNING |
 
 #### Activity Checks
 | Check | Severity |
@@ -56,9 +56,9 @@ For each pipeline, check these categories. Classify findings as:
 #### Policy Checks
 | Check | Severity |
 |-------|----------|
-| Has retry policy | WARNING |
+| Has retry policy | ERROR |
 | Retry 1-5 | ERROR |
-| Has timeout | WARNING |
+| Has timeout | ERROR |
 | Timeout ≤ 7 days | ERROR |
 
 #### Parameterization Checks
@@ -72,7 +72,9 @@ For each pipeline, check these categories. Classify findings as:
 | Check | Severity |
 |-------|----------|
 | No plaintext secrets | ERROR |
-| Secure I/O on credentials | WARNING |
+| Secure I/O on credentials | ERROR |
+| SecureInput on Key Vault activities | ERROR |
+| SecureInput on activities with connection strings | ERROR |
 
 ### 3. Check Knowledge Base
 
@@ -83,8 +85,9 @@ Query `rules/common_issues.json` for known issues:
 - **KB-011**: Missing Error Row Handling
 - **KB-012**: Unpartitioned Large Table Copy
 - **KB-020**: Plaintext Secret in Pipeline
-- **KB-021**: Missing SecureInput on Web Activity
+- **KB-021**: Missing SecureInput on Credential Activity
 - **KB-030**: Data Flow Without Compute Optimization
+- **KB-031**: Data Flow Without Staging
 - **KB-040**: Unbounded ForEach
 - **KB-041**: Missing Pipeline Parameters
 

--- a/rules/best_practices.json
+++ b/rules/best_practices.json
@@ -33,14 +33,19 @@
     "security": {
       "description": "Security best practices",
       "flag_plaintext_secrets": true,
-      "recommend_secure_io": ["Copy", "WebActivity", "AzureFunctionActivity"],
-      "secret_keywords": ["password", "secret", "apikey", "api_key", "access_key", "token"]
+      "require_secure_io": ["Copy", "WebActivity", "AzureFunctionActivity", "Lookup"],
+      "secure_io_severity": "error",
+      "require_secure_input_on_keyvault": true,
+      "secret_keywords": ["password", "secret", "apikey", "api_key", "access_key", "token", "connectionstring", "credential"]
     },
     "organization": {
       "description": "Pipeline organization best practices",
       "require_description": true,
-      "require_annotations": false,
-      "require_folder": true
+      "description_severity": "error",
+      "require_annotations": true,
+      "annotations_severity": "warning",
+      "require_folder": true,
+      "folder_severity": "warning"
     }
   }
 }

--- a/rules/common_issues.json
+++ b/rules/common_issues.json
@@ -5,7 +5,7 @@
     "KB-001": {
       "name": "Missing Retry Policy",
       "pattern": "activity without policy.retry",
-      "severity": "warning",
+      "severity": "error",
       "description": "Activities without retry policies will fail permanently on transient errors",
       "resolution": "Add a policy block with retry: 3 and retryIntervalInSeconds: 30",
       "example_fix": {
@@ -34,7 +34,7 @@
     "KB-010": {
       "name": "Small File Iteration Anti-Pattern",
       "pattern": "ForEach activity with GetMetadata + Copy for files",
-      "severity": "warning",
+      "severity": "error",
       "description": "Iterating over many small files with ForEach is inefficient due to API overhead per file",
       "resolution": "Use wildcard file paths with enablePartitionDiscovery for bulk copy operations",
       "details": "Each Copy activity invocation has ~2-3 second overhead. For 1000 files, this adds 30-50 minutes vs seconds for bulk copy",
@@ -49,7 +49,7 @@
     "KB-011": {
       "name": "Missing Error Row Handling",
       "pattern": "Copy activity without enableSkipIncompatibleRow or redirectIncompatibleRowSettings",
-      "severity": "info",
+      "severity": "warning",
       "description": "Copy activities fail entirely on bad rows unless error handling is configured",
       "resolution": "Consider adding redirectIncompatibleRowSettings to capture bad rows for analysis",
       "example_fix": {
@@ -68,7 +68,7 @@
     "KB-012": {
       "name": "Unpartitioned Large Table Copy",
       "pattern": "Copy from SQL without partition option for tables > 1M rows",
-      "severity": "warning",
+      "severity": "error",
       "description": "Copying large tables without partitioning is slow and may timeout",
       "resolution": "Enable parallel copy with partitionOption and appropriate partitionSettings",
       "example_fix": {
@@ -101,9 +101,9 @@
       }
     },
     "KB-021": {
-      "name": "Missing SecureInput on Web Activity",
-      "pattern": "WebActivity without secureInput: true when body contains credentials",
-      "severity": "warning",
+      "name": "Missing SecureInput on Credential Activity",
+      "pattern": "WebActivity, Lookup, or Copy activity handling secrets without secureInput: true",
+      "severity": "error",
       "description": "Web activity inputs are logged unless secureInput is enabled",
       "resolution": "Set secureInput: true in the activity policy when passing sensitive data",
       "example_fix": {
@@ -129,7 +129,7 @@
     "KB-031": {
       "name": "Data Flow Without Staging",
       "pattern": "ExecuteDataFlow with PolyBase sink without staging configured",
-      "severity": "warning",
+      "severity": "error",
       "description": "PolyBase sinks require staging storage for optimal performance",
       "resolution": "Configure staging linked service and enable staging",
       "example_fix": {
@@ -145,7 +145,7 @@
     "KB-040": {
       "name": "Unbounded ForEach",
       "pattern": "ForEach without isSequential and batchCount > 20",
-      "severity": "warning",
+      "severity": "error",
       "description": "Large parallel ForEach can overwhelm downstream systems and hit API limits",
       "resolution": "Set batchCount appropriate to downstream system capacity (typically 10-20)",
       "example_fix": {
@@ -159,7 +159,7 @@
     "KB-041": {
       "name": "Missing Pipeline Parameters",
       "pattern": "Pipeline without parameters section",
-      "severity": "warning",
+      "severity": "error",
       "description": "Pipelines without parameters are not reusable across environments",
       "resolution": "Define parameters for all environment-specific values (connections, paths, dates)",
       "example_fix": {


### PR DESCRIPTION
…rity, retry, timeout, and parameterization checks

- best_practices.json: security secure I/O → error severity, require_secure_input_on_keyvault flag, require annotations/folder as warning, description as error
- common_issues.json: KB-001 (missing retry) → error, KB-010 (small file iteration) → error, KB-011 (error row handling) → warning (was info), KB-012 (unpartitioned copy) → error, KB-021 (missing secureInput) → error, KB-031 (DF without staging) → error, KB-040 (unbounded ForEach) → error, KB-041 (missing parameters) → error
- adf-review.agent.md: severity tables updated to match; added explicit Key Vault and connection string secureInput checks